### PR TITLE
Add Trivy vulnerability scanner in IaC mode and upload scan results t…

### DIFF
--- a/.github/workflows/tf-module-actions.yml
+++ b/.github/workflows/tf-module-actions.yml
@@ -20,3 +20,17 @@ jobs:
         output-file: README.md
         output-method: inject
         git-push: "true"
+    - name: Run Trivy vulnerability scanner in IaC mode
+      uses: aquasecurity/trivy-action@master
+      with:
+          scan-type: 'config'
+          hide-progress: false
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This commit adds a new step to the workflow that runs Trivy vulnerability scanner in Infrastructure as Code (IaC) mode. The scanner is configured to scan for critical and high severity vulnerabilities, and the results are saved in SARIF format. Additionally, this commit includes another step that uploads the Trivy scan results to the GitHub Security tab using the codeql-action/upload-sarif action.