### PR TITLE
feat: add memory_size variable for Lambda Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ No modules.
 | <a name="input_email"></a> [email](#input\_email) | List of e-mail addresses subscribing to the SNS topic. Default is empty list. | `list(string)` | `[]` | no |
 | <a name="input_ignore_states"></a> [ignore\_states](#input\_ignore\_states) | Suppress warnings for the listed MSK states. Default: ['MAINTENANCE'] | `list(string)` | <pre>[<br>  "MAINTENANCE"<br>]</pre> | no |
 | <a name="input_log_retion_period_in_days"></a> [log\_retion\_period\_in\_days](#input\_log\_retion\_period\_in\_days) | Number of days logs will be retained. Default is 365 days. | `number` | `365` | no |
+| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Amount of memory in MByte that the Lambda Function can use at runtime. Default is 160. | `number` | `160` | no |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | The schedule expression for the CloudWatch event rule. Default is 'rate(15 minutes)'. | `string` | `"rate(15 minutes)"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. Default is empty map. | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ resource "aws_lambda_function" "msk_health_lambda" {
   handler                        = "index.lambda_handler"
   runtime                        = "python3.11"
   reserved_concurrent_executions = 1
-  memory_size                    = 128
+  memory_size                    = var.memory_size
   source_code_hash               = data.archive_file.status_checker_code.output_base64sha256
   timeout                        = 60
   tags                           = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,16 @@ variable "log_retion_period_in_days" {
   }
 }
 
+variable "memory_size" {
+  type        = number
+  description = "Amount of memory in MByte that the Lambda Function can use at runtime. Default is 160."
+  default     = 160
+  validation {
+    condition     = var.memory_size >= 128 && var.memory_size <= 10240
+    error_message = "memory_size must be between 128 and 10240"
+  }
+}
+
 variable "schedule_expression" {
   description = "The schedule expression for the CloudWatch event rule. Default is 'rate(15 minutes)'."
   type        = string


### PR DESCRIPTION
This commit adds a new variable, `memory_size`, to specify the amount of memory in MByte that the Lambda Function can use at runtime. The default value is set to 160. The validation ensures that the `memory_size` is between 128 and 10240.